### PR TITLE
Bug in OML-current for kappa=3 and alpha=0.

### DIFF
--- a/langmuir/analytical.py
+++ b/langmuir/analytical.py
@@ -194,9 +194,17 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
         F = (1.+8*alpha)/(1.+24*alpha)
     else:
         C = np.sqrt(kappa-1.5)*gamma(kappa-1.)/gamma(kappa-0.5)
-        D = (1.+24*alpha*((kappa-1.5)**2/((kappa-2.)*(kappa-3.))))/(1.+15*alpha*((kappa-1.5)/(kappa-2.5)))
-        E = 4.*alpha*kappa*(kappa-1.)/( (kappa-2.)*(kappa-3.)+24*alpha*(kappa-1.5)**2 )
-        F = ((kappa-1.)*(kappa-2.)*(kappa-3.)+8*alpha*(kappa-3.)*(kappa-1.5)**2) /( (kappa-2.)*(kappa-3.)*(kappa-1.5)+24*alpha*(kappa-1.5)**3 )
+        if alpha == 0:
+            D = 1.
+            E = 0.
+            F = (kappa-1.) / (kappa-1.5)
+        else:
+            assert kappa > 3., "Invalid value: for alpha > 0, kappa must be larger than 3."
+            D = (1. + 24 * alpha * ((kappa - 1.5) ** 2 / ((kappa - 2.) * (kappa - 3.)))) / (
+                        1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
+            E = 4. * alpha * kappa * (kappa - 1.) / ((kappa - 2.) * (kappa - 3.) + 24 * alpha * (kappa - 1.5) ** 2)
+            F = ((kappa - 1.) * (kappa - 2.) * (kappa - 3.) + 8 * alpha * (kappa - 3.) * (kappa - 1.5) ** 2) / (
+                        (kappa - 2.) * (kappa - 3.) * (kappa - 1.5) + 24 * alpha * (kappa - 1.5) ** 3)
 
     if normalization is None:
         I0 = normalization_current(geometry, species)
@@ -243,16 +251,22 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
 
         else:
             C = np.sqrt(kappa - 1.5) * (kappa - .5) / (kappa - 1.0)
-            D = (1. + 3 * alpha * ((kappa - 1.5) / (kappa - 0.5))) / \
-                (1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
-            E = 4. * alpha * kappa * \
-                (kappa - 1.) / ((kappa - .5) *
-                                (kappa - 1.5) + 3. * alpha * (kappa - 1.5)**2)
+            if alpha == 0:
+                I[indices_p] = (2. / np.sqrt(np.pi)) * I0 * C
+                I[indices_p] *= (eta[indices_p] / (kappa - 1.5)) ** (1. - kappa)
+                I[indices_p] *= hyp2f1(kappa - 1., kappa + .5, kappa, 1. - (kappa - 1.5) / (eta[indices_p]))
+            else:
+                assert kappa > 3., "Invalid value: for alpha > 0, kappa must be larger than 3."
+                D = (1. + 3 * alpha * ((kappa - 1.5) / (kappa - 0.5))) / \
+                    (1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
+                E = 4. * alpha * kappa * \
+                    (kappa - 1.) / ((kappa - .5) *
+                                    (kappa - 1.5) + 3. * alpha * (kappa - 1.5)**2)
 
-            I[indices_p] = (2./np.sqrt(np.pi))*I0 * C * D * (eta[indices_p]/(kappa-1.5))**(1.-kappa) * \
-                (((kappa - 1.) / (kappa - 3.)) * E * (eta[indices_p]**2) * hyp2f1(kappa - 3, kappa + .5, kappa - 2., 1. - (kappa - 1.5) / (eta[indices_p])) + \
-                ((kappa - 1.5 - 2. * (kappa - 1.) * eta[indices_p]) / (kappa - 2.)) * E * eta[indices_p] * hyp2f1(kappa - 2, kappa + .5, kappa - 1., 1. - (kappa - 1.5) / (eta[indices_p])) +
-                (1. + E * eta[indices_p] * (eta[indices_p]-((kappa-1.5)/(kappa-1.)))) * hyp2f1(kappa - 1., kappa + .5, kappa, 1. - (kappa - 1.5) / (eta[indices_p])))
+                I[indices_p] = (2./np.sqrt(np.pi))*I0 * C * D * (eta[indices_p]/(kappa-1.5))**(1.-kappa) * \
+                    (((kappa - 1.) / (kappa - 3.)) * E * (eta[indices_p]**2) * hyp2f1(kappa - 3, kappa + .5, kappa - 2., 1. - (kappa - 1.5) / (eta[indices_p])) + \
+                    ((kappa - 1.5 - 2. * (kappa - 1.) * eta[indices_p]) / (kappa - 2.)) * E * eta[indices_p] * hyp2f1(kappa - 2, kappa + .5, kappa - 1., 1. - (kappa - 1.5) / (eta[indices_p])) +
+                    (1. + E * eta[indices_p] * (eta[indices_p]-((kappa-1.5)/(kappa-1.)))) * hyp2f1(kappa - 1., kappa + .5, kappa, 1. - (kappa - 1.5) / (eta[indices_p])))
 
     else:
         raise ValueError('Geometry not supported: {}'.format(geometry))

--- a/langmuir/analytical.py
+++ b/langmuir/analytical.py
@@ -144,7 +144,7 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
         charge and temperature and k is Boltzmann's constant.
 
     normalization: 'th', 'thmax', None
-        Wether to normalize the output current by, respectively, the thermal
+        Whether to normalize the output current by, respectively, the thermal
         current, the Maxwellian thermal current, or not at all, i.e., current
         in [A/m].
 
@@ -195,10 +195,12 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
     else:
         C = np.sqrt(kappa-1.5)*gamma(kappa-1.)/gamma(kappa-0.5)
         if alpha == 0:
+            assert kappa > 1.5, "Invalid value: kappa must be larger than 3/2."
             D = 1.
             E = 0.
             F = (kappa-1.) / (kappa-1.5)
         else:
+            # For Kappa-Cairns distribution, kappa must be bigger than 3:
             assert kappa > 3., "Invalid value: for alpha > 0, kappa must be larger than 3."
             D = (1. + 24 * alpha * ((kappa - 1.5) ** 2 / ((kappa - 2.) * (kappa - 3.)))) / (
                         1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
@@ -252,6 +254,7 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
         else:
             C = np.sqrt(kappa - 1.5) * (kappa - .5) / (kappa - 1.0)
             if alpha == 0:
+                assert kappa > 1.5, "Invalid value: kappa must be larger than 3/2."
                 I[indices_p] = (2. / np.sqrt(np.pi)) * I0 * C
                 I[indices_p] *= (eta[indices_p] / (kappa - 1.5)) ** (1. - kappa)
                 I[indices_p] *= hyp2f1(kappa - 1., kappa + .5, kappa, 1. - (kappa - 1.5) / (eta[indices_p]))

--- a/langmuir/analytical.py
+++ b/langmuir/analytical.py
@@ -195,13 +195,15 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
     else:
         C = np.sqrt(kappa-1.5)*gamma(kappa-1.)/gamma(kappa-0.5)
         if alpha == 0:
-            assert kappa > 1.5, "Invalid value: kappa must be larger than 3/2."
+            if kappa <= 1.5:
+                raise ValueError("Invalid value: kappa must be larger than 3/2.")
             D = 1.
             E = 0.
             F = (kappa-1.) / (kappa-1.5)
         else:
             # For Kappa-Cairns distribution, kappa must be bigger than 3:
-            assert kappa > 3., "Invalid value: for alpha > 0, kappa must be larger than 3."
+            if kappa <= 3.:
+                raise ValueError("Invalid value: for alpha > 0, kappa must be larger than 3.")
             D = (1. + 24 * alpha * ((kappa - 1.5) ** 2 / ((kappa - 2.) * (kappa - 3.)))) / (
                         1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
             E = 4. * alpha * kappa * (kappa - 1.) / ((kappa - 2.) * (kappa - 3.) + 24 * alpha * (kappa - 1.5) ** 2)
@@ -254,12 +256,14 @@ def OML_current(geometry, species, V=None, eta=None, normalization=None):
         else:
             C = np.sqrt(kappa - 1.5) * (kappa - .5) / (kappa - 1.0)
             if alpha == 0:
-                assert kappa > 1.5, "Invalid value: kappa must be larger than 3/2."
+                if kappa <= 1.5:
+                    raise ValueError("Invalid value: kappa must be larger than 3/2.")
                 I[indices_p] = (2. / np.sqrt(np.pi)) * I0 * C
                 I[indices_p] *= (eta[indices_p] / (kappa - 1.5)) ** (1. - kappa)
                 I[indices_p] *= hyp2f1(kappa - 1., kappa + .5, kappa, 1. - (kappa - 1.5) / (eta[indices_p]))
             else:
-                assert kappa > 3., "Invalid value: for alpha > 0, kappa must be larger than 3."
+                if kappa <= 3.:
+                    raise ValueError("Invalid value: for alpha > 0, kappa must be larger than 3.")
                 D = (1. + 3 * alpha * ((kappa - 1.5) / (kappa - 0.5))) / \
                     (1. + 15 * alpha * ((kappa - 1.5) / (kappa - 2.5)))
                 E = 4. * alpha * kappa * \

--- a/langmuir/species.py
+++ b/langmuir/species.py
@@ -117,6 +117,10 @@ class Species(object):
         if self.kappa == float('inf'):
             self.debye = np.sqrt(eps0*k*self.T/(self.q**2*self.n))*np.sqrt((1.0 + 15.0*self.alpha)/(1.0 + 3.0*self.alpha))
         else:
+            # Note: Problematic kappa values:
+            #   - ZeroDivisionError for kappa = 1.0, 1.5
+            if self.kappa in [0.5, 2.5]:
+                raise ValueError("Invalid value: kappa cannot be 0.5 or 2.5")
             self.debye = np.sqrt(eps0 * k * self.T / (self.q**2 * self.n)) *\
                          np.sqrt(((self.kappa - 1.5) / (self.kappa - 0.5)) *\
                         ((1.0 + 15.0 * self.alpha * ((self.kappa - 1.5) / (self.kappa - 2.5))) / (1.0 + 3.0 * self.alpha * ((self.kappa - 1.5) / (self.kappa - 0.5)))))

--- a/langmuir/test_analytical.py
+++ b/langmuir/test_analytical.py
@@ -191,15 +191,24 @@ def test_OML_current_kappa_cairns():
     assert(I == approx(-2.26604e-11))
 
 
-@pytest.mark.parametrize("kappa, alpha, eta", [(3, 0, 5), (3, 0.2, 5), (3, 0, -5), (3, 0.2, -5), (1.5, 0, 5),
-                                               (1.5, 0, -5)])
+@pytest.mark.parametrize("kappa, alpha, eta", [(.5, 0, 5), (.5, 0.2, 5), (.5, 0, -5), (.5, 0.2, -5),
+                                               (1., 0, 5), (1., 0.2, 5), (1., 0, -5), (1., 0.2, -5),
+                                               (1.5, 0, 5), (1.5, 0, -5), (1.5, 0, -5), (1.5, 0.2, -5),
+                                               (2.0, 0, 5), (2, 0.2, 5), (2, 0, -5), (2, 0.2, -5),
+                                               (2.5, 0, 5), (2.5, 0.2, 5), (2.5, 0, -5), (2.5, 0.2, -5),
+                                               (3, 0, 5), (3, 0.2, 5), (3, 0, -5), (3, 0.2, -5)])
 def test_valid_kappa_and_alpha_values(kappa, alpha, eta):
-    sp = Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)
-    geometries = [Cylinder(0.255e-3, 25e-3), Sphere(0.255e-3)]
+    if kappa in [0.5, 2.5]:
+        with pytest.raises(ValueError):
+            Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)
+        return
+    else:
+        sp = Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)
 
+    geometries = [Cylinder(0.255e-3, 25e-3), Sphere(0.255e-3)]
     for geo in geometries:
         if alpha == 0:
-            if kappa == 1.5:
+            if kappa in [1., 1.5]:
                 with pytest.raises(ValueError):
                     OML_current(geo, sp, eta=eta)
             else:

--- a/langmuir/test_analytical.py
+++ b/langmuir/test_analytical.py
@@ -200,12 +200,12 @@ def test_valid_kappa_and_alpha_values(kappa, alpha, eta):
     for geo in geometries:
         if alpha == 0:
             if kappa == 1.5:
-                with pytest.raises(AssertionError):
+                with pytest.raises(ValueError):
                     OML_current(geo, sp, eta=eta)
             else:
                 assert OML_current(geo, sp, eta=eta)
         else:
-            with pytest.raises(AssertionError):
+            with pytest.raises(ValueError):
                 OML_current(geo, sp, eta=eta)
 
 

--- a/langmuir/test_analytical.py
+++ b/langmuir/test_analytical.py
@@ -190,6 +190,20 @@ def test_OML_current_kappa_cairns():
     I = OML_current(geo, sp_k, eta=-5)
     assert(I == approx(-2.26604e-11))
 
+
+@pytest.mark.parametrize("kappa, alpha, eta", [(3, 0, 5), (3, 0.2, 5), (3, 0, -5), (3, 0.2, -5)])
+def test_valid_kappa_and_alpha_values(kappa, alpha, eta):
+    sp = Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)
+    geometries = [Cylinder(0.255e-3, 25e-3), Sphere(0.255e-3)]
+
+    for geo in geometries:
+        if alpha == 0:
+            assert OML_current(geo, sp, eta=eta)
+        else:
+            with pytest.raises(AssertionError):
+                OML_current(geo, sp, eta=eta)
+
+
 def test_jacobsen_density_identity():
     # Tests that the Jacobsen methods agrees perfectly with OML
     n = [1e11, 5e11, 1e12]

--- a/langmuir/test_analytical.py
+++ b/langmuir/test_analytical.py
@@ -191,14 +191,19 @@ def test_OML_current_kappa_cairns():
     assert(I == approx(-2.26604e-11))
 
 
-@pytest.mark.parametrize("kappa, alpha, eta", [(3, 0, 5), (3, 0.2, 5), (3, 0, -5), (3, 0.2, -5)])
+@pytest.mark.parametrize("kappa, alpha, eta", [(3, 0, 5), (3, 0.2, 5), (3, 0, -5), (3, 0.2, -5), (1.5, 0, 5),
+                                               (1.5, 0, -5)])
 def test_valid_kappa_and_alpha_values(kappa, alpha, eta):
     sp = Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)
     geometries = [Cylinder(0.255e-3, 25e-3), Sphere(0.255e-3)]
 
     for geo in geometries:
         if alpha == 0:
-            assert OML_current(geo, sp, eta=eta)
+            if kappa == 1.5:
+                with pytest.raises(AssertionError):
+                    OML_current(geo, sp, eta=eta)
+            else:
+                assert OML_current(geo, sp, eta=eta)
         else:
             with pytest.raises(AssertionError):
                 OML_current(geo, sp, eta=eta)

--- a/langmuir/test_species.py
+++ b/langmuir/test_species.py
@@ -155,3 +155,9 @@ def test_debye():
 def test_negative_temperature(caplog):
     sp = Species(n=1e11, T=-1)
     assert(caplog.records[0].levelname == 'WARNING')
+
+
+@pytest.mark.parametrize("kappa, alpha", [(.5, 0), (.5, 0.2), (2.5, 0), (2.5, 0.2)])
+def test_invalid_kappa_values(kappa, alpha):
+    with pytest.raises(ValueError):
+        Electron(n=1e11, T=1000, kappa=kappa, alpha=alpha)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [tool:pytest]
-addopts = --cov langmuir --cov-report term-missing
+#addopts = --cov langmuir --cov-report term-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [tool:pytest]
-#addopts = --cov langmuir --cov-report term-missing
+addopts = --cov langmuir --cov-report term-missing


### PR DESCRIPTION
**Tasks**

1. Proper handling of invalid kappa and alpha values in OML-current calculations.
2. Add tests covering invalid values for various input parameters.

Closes #34  